### PR TITLE
Fixed wordpress user login validation

### DIFF
--- a/lib/msf/core/exploit/remote/http/wordpress/users.rb
+++ b/lib/msf/core/exploit/remote/http/wordpress/users.rb
@@ -14,7 +14,8 @@ module Msf::Exploit::Remote::HTTP::Wordpress::Users
 
     return true if res and res.code == 200 and
         (res.body.to_s =~ /Incorrect password/ or
-            res.body.to_s =~ /document\.getElementById\('user_pass'\)/)
+            res.body.to_s =~ /document\.getElementById\('user_pass'\)/ or
+            res.body.to_s =~/<\/strong> is incorrect/)
 
     return false
   end


### PR DESCRIPTION
## Problem Encountered

While trying using 

`module> auxiliary/scanner/http/wordpress_login_enum`

User validation does not occur correctly in wordpress 5.x



## Verification

- mkdir wordpress
- cd wordpress
- nano docker-compose.yml
- Enter the following into the file

```
version: '3.3'
services:
   db:
     image: mysql:5.7
     volumes:
       - db_data:/var/lib/mysql
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: somewordpress
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress

   wordpress:
     depends_on:
       - db
     image: wordpress:latest
     ports:
       - "8000:80"
     restart: always
     environment:
       WORDPRESS_DB_HOST: db:3306
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
       WORDPRESS_DB_NAME: wordpress
volumes:
    db_data: {}
```
- sudo docker-compose up -d

- Follow the setup instructions at 127.0.0.1:8000 and set up a new user in WordPress.
- Start msfconsole
- creds add user:test
- use auxiliary/scanner/http/wordpress_login_enum
- set RHOSTS 127.0.0.1
- set RPORT 8000
- set DB_ALL_USERS true
- run

## Expected Output

```
msf6 > use auxiliary/scanner/http/wordpress_login_enum 
msf6 auxiliary(scanner/http/wordpress_login_enum) > show options

Module options (auxiliary/scanner/http/wordpress_login_enum):

   Name                 Current Setting  Required  Description
   ----                 ---------------  --------  -----------
   BLANK_PASSWORDS      false            no        Try blank passwords for all users
   BRUTEFORCE           true             yes       Perform brute force authentication
   BRUTEFORCE_SPEED     5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS         false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS          false            no        Add all passwords in the current database to the list
   DB_ALL_USERS         false            no        Add all users in the current database to the list
   ENUMERATE_USERNAMES  true             yes       Enumerate usernames
   PASSWORD                              no        A specific password to authenticate with
   PASS_FILE                             no        File containing passwords, one per line
   Proxies                               no        A proxy chain of format type:host:port[,type:host:port][...]
   RANGE_END            10               no        Last user id to enumerate
   RANGE_START          1                no        First user id to enumerate
   RHOSTS                                yes       The target host(s), range CIDR identifier, or hosts file with syntax 'file:<path>'
   RPORT                80               yes       The target port (TCP)
   SSL                  false            no        Negotiate SSL/TLS for outgoing connections
   STOP_ON_SUCCESS      false            yes       Stop guessing when a credential works for a host
   TARGETURI            /                yes       The base path to the wordpress application
   THREADS              1                yes       The number of concurrent threads (max one per host)
   USERNAME                              no        A specific username to authenticate as
   USERPASS_FILE                         no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS         false            no        Try the username as the password for all users
   USER_FILE                             no        File containing usernames, one per line
   VALIDATE_USERS       true             yes       Validate usernames
   VERBOSE              true             yes       Whether to print output for all attempts
   VHOST                                 no        HTTP server virtual host

msf6 auxiliary(scanner/http/wordpress_login_enum) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 auxiliary(scanner/http/wordpress_login_enum) > set RPORT 8080
RPORT => 8080
msf6 auxiliary(scanner/http/wordpress_login_enum) > set DB_ALL_USERS true
DB_ALL_USERS => true
msf6 auxiliary(scanner/http/wordpress_login_enum) > run

[-] The connection was refused by the remote host (127.0.0.1:8080).
[-] / does not seem to be WordPress site
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/wordpress_login_enum) > set RPORT 8000
RPORT => 8000
msf6 auxiliary(scanner/http/wordpress_login_enum) > run

[*] / - WordPress Version 5.6.1 detected
[*] 127.0.0.1:8000 - / - WordPress User-Enumeration - Running User Enumeration
[*] 127.0.0.1:8000 - / - WordPress User-Validation - Running User Validation
[*] / - WordPress User-Validation - Checking Username:'Administrator'
[-] 127.0.0.1:8000 - [1/4] - / - WordPress User-Validation - Invalid Username: 'Administrator'
[*] / - WordPress User-Validation - Checking Username:'administrator'
[-] 127.0.0.1:8000 - [2/4] - / - WordPress User-Validation - Invalid Username: 'administrator'
[*] / - WordPress User-Validation - Checking Username:'test'
[+] / - WordPress User-Validation - Username: 'test' - is VALID
[+] / - WordPress User-Validation - Found 1 valid user
[-] 127.0.0.1:8000 - [4/4] - / - WordPress User-Validation - Invalid Username: 'normal'
[*] 127.0.0.1:8000 - [5/4] - / - WordPress Brute Force - Running Bruteforce
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf6 auxiliary(scanner/http/wordpress_login_enum) > 

```

## Linked Issue

[https://github.com/rapid7/metasploit-framework/issues/14790#issue-81372544](https://github.com/rapid7/metasploit-framework/issues/14790#issue-813725448,"https://github.com/rapid7/metasploit-framework/issues/14790#issue-813725448")

Please remind me if any issue is found with the fix! ;-)